### PR TITLE
Cloudflare Pagesのデフォルトドメインをインデックスさせない

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,2 @@
+https://:project.pages.dev/*
+  X-Robots-Tag: noindex


### PR DESCRIPTION
https://developers.cloudflare.com/pages/platform/headers/#prevent-your-pagesdev-deployments-showing-in-search-results